### PR TITLE
libopenbsd/pwd.c, ls/ls.c: fix segfault

### DIFF
--- a/libopenbsd/pwd.c
+++ b/libopenbsd/pwd.c
@@ -23,8 +23,9 @@ gid_from_group(const char *name, gid_t *gid)
 const char *
 group_from_gid(gid_t gid, int nogroup)
 {
-
-	return (getgrgid(gid)->gr_name);
+	if (getgrgid(gid) != NULL)
+		return (getgrgid(gid)->gr_name);
+	return (getgrgid(nogroup)->gr_name);
 }
 
 int
@@ -43,6 +44,7 @@ uid_from_user(const char *name, uid_t *uid)
 const char *
 user_from_uid(uid_t uid, int nouser)
 {
-
-	return (getpwuid(uid)->pw_name);
+	if (getpwuid(uid) != NULL)
+		return (getpwuid(uid)->pw_name);
+	return (getpwuid(nouser)->pw_name);
 }

--- a/ls/ls.c
+++ b/ls/ls.c
@@ -498,8 +498,8 @@ display(FTSENT *p, FTSENT *list)
 					user = nuser;
 					group = ngroup;
 				} else {
-					user = getpwuid(sp->st_uid)->pw_name;
-					group = getgrgid(sp->st_gid)->gr_name;
+					user = user_from_uid(sp->st_uid, 0);
+					group = group_from_gid(sp->st_gid, 0);
 				}
 				if ((ulen = strlen(user)) > maxuser)
 					maxuser = ulen;


### PR DESCRIPTION
libopenbsd/pwd.c, ls/ls.c: fix segfault on name lookup when uid/gid not present in /etc/passwd or /etc/group

Noticed a segfault on a name lookup for uid/gid not found; numeric IDs work as expected. This patch does a minor fixup, converting ls.c to use user_from_uid and group_from_gid with a NULL check on getpwuid and getgrgid in libopenbsd/pwd.c. Let me know if this works. Thanks!

- https://github.com/openbsd/src/blob/master/bin/ls/ls.c

```
$ /usr/local/crosware/software/baseutils/baseutils-c43e028b59f3d464fcd47a872e1102ee8601df6b/bin/ls -lA /
Segmentation fault (core dumped)
$ /usr/local/crosware/software/baseutils/baseutils-c43e028b59f3d464fcd47a872e1102ee8601df6b/bin/ls -lAn /
total 8
-rwxr-xr-x    1 0     0        0 Apr 13 23:27 .dockerenv
lrwxrwxrwx    1 0     0        9 Apr  6 04:54 bin -> /usr/bin/
drwxr-xr-x   15 0     0     3780 Apr 13 23:27 dev
drwxr-xr-x    1 0     0       66 Apr 13 23:27 etc
drwxrwxr-x    4 1000  1000    59 Feb 28  2019 go-misc
drwxr-xr-x    2 0     0        6 Apr  6 04:54 home
lrwxrwxrwx    1 0     0        8 Apr  6 06:17 lib -> /usr/lib
lrwxrwxrwx    1 0     0       10 Apr  6 06:17 lib64 -> /usr/lib64
dr-xr-xr-x  193 0     0        0 Apr 13 23:27 proc
drwx------    1 0     0       22 Apr 13 23:32 root
drwxr-xr-x    2 0     0        6 Apr  6 04:54 run
lrwxrwxrwx    1 0     0        9 Apr  6 04:54 sbin -> /usr/bin/
dr-xr-xr-x   13 0     0        0 Apr  3 04:32 sys
drwxrwxrwt    3 0     0     4096 Apr 14 00:15 tmp
drwxr-xr-x    1 0     0       19 Apr  6 06:17 usr
drwxr-xr-x    1 0     0       17 Apr  6 04:54 var
$ /usr/local/crosware/software/baseutils/baseutils-c94996162fd53f817fee09e424150a88bdf8677a/bin/ls -lA /
total 8
-rwxr-xr-x    1 root  root     0 Apr 13 23:27 .dockerenv
lrwxrwxrwx    1 root  root     9 Apr  6 04:54 bin -> /usr/bin/
drwxr-xr-x   15 root  root  3780 Apr 13 23:27 dev
drwxr-xr-x    1 root  root    66 Apr 13 23:27 etc
drwxrwxr-x    4 root  root    59 Feb 28  2019 go-misc
drwxr-xr-x    2 root  root     6 Apr  6 04:54 home
lrwxrwxrwx    1 root  root     8 Apr  6 06:17 lib -> /usr/lib
lrwxrwxrwx    1 root  root    10 Apr  6 06:17 lib64 -> /usr/lib64
dr-xr-xr-x  193 root  root     0 Apr 13 23:27 proc
drwx------    1 root  root    22 Apr 13 23:32 root
drwxr-xr-x    2 root  root     6 Apr  6 04:54 run
lrwxrwxrwx    1 root  root     9 Apr  6 04:54 sbin -> /usr/bin/
dr-xr-xr-x   13 root  root     0 Apr  3 04:32 sys
drwxrwxrwt    3 root  root  4096 Apr 14 00:15 tmp
drwxr-xr-x    1 root  root    19 Apr  6 06:17 usr
drwxr-xr-x    1 root  root    17 Apr  6 04:54 var
```